### PR TITLE
feat(Turbo): Added ability to use Turbo for uploading data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Import the SDK:
 import AtomicToolkit from 'atomic-toolkit';
 ```
 
-## Initialize with Arweave Wallet or Irys SDK
+## Initialize with Arweave Wallet, Irys SDK, or Turbo SDK
 
 Using Arweave Wallet
 
@@ -66,6 +66,18 @@ await irys.ready();
 const toolkit = new AtomicToolkit({ irys });
 ```
 
+using Turbo:
+
+```ts
+const { TurboFactory } = require('@ardrive/turbo-sdk');
+const AtomicToolkit = require('atomic-toolkit').default;
+const fs = require('fs');
+
+const jwk = JSON.parse(fs.readFileSync('./KeyFile.json'));
+const turbo = TurboFactory.authenticated({ privateKey: jwk });
+
+const toolkit = new AtomicToolkit({ turbo });
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ await irys.ready();
 const toolkit = new AtomicToolkit({ irys });
 ```
 
-using Turbo:
+Using Turbo:
 
 ```ts
 const { TurboFactory } = require('@ardrive/turbo-sdk');
@@ -77,6 +77,26 @@ const jwk = JSON.parse(fs.readFileSync('./KeyFile.json'));
 const turbo = TurboFactory.authenticated({ privateKey: jwk });
 
 const toolkit = new AtomicToolkit({ turbo });
+```
+
+Using Turbo in the web:
+
+```ts
+import { ArconnectSigner } from 'arbundles/web';
+import { TurboFactory } from '@ardrive/turbo-sdk/web';
+import { AtomicToolkitWeb } from 'atomic-toolkit';
+
+async function connectToolkit() {
+    await window.arweaveWallet.connect([
+        'ACCESS_PUBLIC_KEY',
+        'SIGNATURE',
+        'ACCESS_ADDRESS',
+        'SIGN_TRANSACTION',
+    ]);
+    const arConnectSigner = new ArconnectSigner(window.arweaveWallet);
+    const turbo = await TurboFactory.authenticated({ signer: arConnectSigner });
+    const toolkit = new AtomicToolkitWeb({ turbo });
+}
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ await irys.ready();
 const toolkit = new AtomicToolkit({ irys });
 ```
 
+Using Turbo Through Irys:
+
+```ts
+import Irys from '@irys/sdk';
+
+const irys = new Irys({
+    url: 'https://up.arweave.net',
+    token: 'matic',
+    key: 'your-private-key',
+});
+
+await irys.ready();
+
+const toolkit = new AtomicToolkit({ irys });
+```
+
+
 ## Documentation
 
 For a complete overview of available functions and usage examples, please refer to the official documentation: [https://atomictoolkit.mintlify.app](https://atomictoolkit.mintlify.app/introduction)

--- a/apps/docs/guides/collection/create-collection.mdx
+++ b/apps/docs/guides/collection/create-collection.mdx
@@ -39,18 +39,29 @@ For details on the options see the [Create Collection Options](/types-reference/
 
 ### Return Value
 
-The function returns a promise that resolves to `UploadResponse` or `Transaction` depending on whether Irys is used or not.
+The function returns a promise that resolves to `UploadResponse`, `Transaction`, or `TurboUploadDataItemResponse` depending on whether Irys or Turbo are used or not.
 
--   `UploadResonse` - Returned when Irys is used. It contains feilds such as:
+-   `UploadResponse` - Returned when Irys is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
     -   **timestamp: `number`** - The timestamp of the transaction.
--   `Transaction` - Returned when Arweave is used. It contains feilds such as:
+-   `Transaction` - Returned when Arweave is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **owner: `string`** - The owner of the collection.
     -   **tags: `Tag[]`** - The tags of the collection.
     -   **data: `Uint8Array`** - The data of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
+-   `TurboUploadDataItemResponse` - Returned when Turbo is used. It contains fields such as: 
+    -   **id: `string`** - The transaction ID of the collection,
+    -   **timestamp: `number`** - The timestamp of the transaction,
+    -   **winc: `string`** - The amount of Turbo Credits, in Winston Credits, spent on the upload,
+    -   **version: `string`** - The version number of the upload receipt returned,
+    -   **deadlineHeight: `number`** - The latest block height in which the uploaded data will be settled on Arweave,
+    -   **dataCaches: `array`** - A list of nodes where the data was cached while upload to Arweave is pending,
+    -   **fastFinalityIndexes: `array`** - A list of nodes where data is made available while waiting for it to settle on Arweave,
+    -   **public: `string`** - The public key of the wallet used for upload,
+    -   **signature: `string`** - The signature used while creating the collection,
+    -   **owner: `string`** - The owner of the collection.
 
 ### Example Usage
 

--- a/apps/docs/guides/collection/create-collection.mdx
+++ b/apps/docs/guides/collection/create-collection.mdx
@@ -134,18 +134,30 @@ For details on the options see the [Create Collection Options](/types-reference/
 
 ### Return Value
 
-The function returns a function called `mutateAsync` which when called returns a promise that will resolve to `UploadResponse` or `Transaction` depending on whether Irys is used or not.
+The function returns a function called `mutateAsync` which when called returns a promise that will resolve to `UploadResponse`, `Transaction`, or `TurboUploadDataItemResponse` depending on whether Irys or Turbo are used or not.
 
--   `UploadResonse` - Returned when Irys is used. It contains feilds such as:
+-   `UploadResponse` - Returned when Irys is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
     -   **timestamp: `number`** - The timestamp of the transaction.
--   `Transaction` - Returned when Arweave is used. It contains feilds such as:
+-   `Transaction` - Returned when Arweave is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **owner: `string`** - The owner of the collection.
     -   **tags: `Tag[]`** - The tags of the collection.
     -   **data: `Uint8Array`** - The data of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
+-   `TurboUploadDataItemResponse` - Returned when Turbo is used. It contains fields such as: 
+    -   **id: `string`** - The transaction ID of the collection,
+    -   **timestamp: `number`** - The timestamp of the transaction,
+    -   **winc: `string`** - The amount of Turbo Credits, in Winston Credits, spent on the upload,
+    -   **version: `string`** - The version number of the upload receipt returned,
+    -   **deadlineHeight: `number`** - The latest block height in which the uploaded data will be settled on Arweave,
+    -   **dataCaches: `array`** - A list of nodes where the data was cached while upload to Arweave is pending,
+    -   **fastFinalityIndexes: `array`** - A list of nodes where data is made available while waiting for it to settle on Arweave,
+    -   **public: `string`** - The public key of the wallet used for upload,
+    -   **signature: `string`** - The signature used while creating the collection,
+    -   **owner: `string`** - The owner of the collection.
+
 
 <Note>
     You don't need to include the _banner_ and _thumbnail_ feilds in the

--- a/apps/docs/guides/utilities/get-upload-cost.mdx
+++ b/apps/docs/guides/utilities/get-upload-cost.mdx
@@ -68,3 +68,22 @@ const costWithIrys = await toolkit.utils.getUploadCost(10 ** 9); // 1 GB
     }
 }
 ```
+
+```json
+// With Turbo
+{
+  token: 'turbo',
+  cost: { 
+    atomic: '164313830', 
+    formatted: '0.00016431383' 
+  },
+  balance: { 
+    atomic: '517190608', 
+    formatted: '0.000517190608' 
+  },
+  additional: { 
+    atomic: '0', 
+    formatted: '0' 
+  }
+}
+```

--- a/apps/docs/guides/utilities/upload-data.mdx
+++ b/apps/docs/guides/utilities/upload-data.mdx
@@ -23,18 +23,29 @@ The function takes in a object containing the following parameters:
 
 ## Return Value
 
-The function returns a promise that resolves to `UploadResponse` or `Transaction` depending on whether Irys is used or not.
+The function returns a promise that resolves to `UploadResponse`, `Transaction`, or `TurboUploadDataItemResponse` depending on whether Irys or Turbo are used or not.
 
--   `UploadResonse` - Returned when Irys is used. It contains feilds such as:
+-   `UploadResponse` - Returned when Irys is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
     -   **timestamp: `number`** - The timestamp of the transaction.
--   `Transaction` - Returned when Arweave is used. It contains feilds such as:
+-   `Transaction` - Returned when Arweave is used. It contains fields such as:
     -   **id: `string`** - The transaction ID of the collection.
     -   **owner: `string`** - The owner of the collection.
     -   **tags: `Tag[]`** - The tags of the collection.
     -   **data: `Uint8Array`** - The data of the collection.
     -   **signature: `string`** - The signature used while creating the collection.
+-   `TurboUploadDataItemResponse` - Returned when Turbo is used. It contains fields such as: 
+    -   **id: `string`** - The transaction ID of the collection,
+    -   **timestamp: `number`** - The timestamp of the transaction,
+    -   **winc: `string`** - The amount of Turbo Credits, in Winston Credits, spent on the upload,
+    -   **version: `string`** - The version number of the upload receipt returned,
+    -   **deadlineHeight: `number`** - The latest block height in which the uploaded data will be settled on Arweave,
+    -   **dataCaches: `array`** - A list of nodes where the data was cached while upload to Arweave is pending,
+    -   **fastFinalityIndexes: `array`** - A list of nodes where data is made available while waiting for it to settle on Arweave,
+    -   **public: `string`** - The public key of the wallet used for upload,
+    -   **signature: `string`** - The signature used while creating the collection,
+    -   **owner: `string`** - The owner of the collection.
 
 ## Example
 

--- a/apps/docs/usage/browser.mdx
+++ b/apps/docs/usage/browser.mdx
@@ -9,6 +9,7 @@ This section walks through the steps to use Atomic Toolkit in a browser applicat
 
 1. Using Injected Arweave Wallet
 2. Using WebIrys
+3. Using Turbo
 
 ## Using Injected Arweave Wallet
 
@@ -150,3 +151,32 @@ const webIrys = await getWebIrys();
 
 const toolkit = new AtomicToolkitWeb({ warp: warp, irys: webIrys });
 ```
+
+## Using Turbo
+
+This uses an authenticated Turbo instance for uploading data using Turbo credits.
+
+```ts
+import { ArconnectSigner } from 'arbundles/web';
+import { TurboFactory } from '@ardrive/turbo-sdk/web';
+import { AtomicToolkitWeb } from 'atomic-toolkit';
+
+async function connectToolkit() {
+    await window.arweaveWallet.connect([
+        'ACCESS_PUBLIC_KEY',
+        'SIGNATURE',
+        'ACCESS_ADDRESS',
+        'SIGN_TRANSACTION',
+    ]);
+    const arConnectSigner = new ArconnectSigner(window.arweaveWallet);
+    const turbo = await TurboFactory.authenticated({ signer: arConnectSigner });
+    const toolkit = new AtomicToolkitWeb({ turbo });
+}
+```
+
+### Input Parameters
+
+The following params are available and they must be passed in as an object:
+
+-   **warp (optional)**: `Warp`: A Warp Instance to use with Deploy Plugin. If not provided, the default Warp instance for Mainnet will be used.
+-   **turbo**: `TurboAuthenticatedClient`: An authenticated Turbo Instance to use for uploading data.

--- a/apps/docs/usage/server-side.mdx
+++ b/apps/docs/usage/server-side.mdx
@@ -32,6 +32,7 @@ The following params are available for this function and they must be passed in 
 -   **warp (optional)**: `Warp`: A Warp Instance to use with Deploy Plugin. If not provided, the default Warp instance for Mainnet will be used.
 -   **arweave (optional)**: `Arweave`: An Arweave Instance to use. If not provided, the default Arweave instance with gateway [arweave.net](arweave.net) will be used.
 -   **key**: `JWKInterface`: The Key to use for signing transactions. Should be a JWK object.
+-   **turbo (optional)**: An authenticated Turbo instance to use for uploading with Turbo.
 
 <Warning>
     Private keys must be kept secure at all times. Please ensure that the

--- a/apps/docs/usage/server-side.mdx
+++ b/apps/docs/usage/server-side.mdx
@@ -32,7 +32,6 @@ The following params are available for this function and they must be passed in 
 -   **warp (optional)**: `Warp`: A Warp Instance to use with Deploy Plugin. If not provided, the default Warp instance for Mainnet will be used.
 -   **arweave (optional)**: `Arweave`: An Arweave Instance to use. If not provided, the default Arweave instance with gateway [arweave.net](arweave.net) will be used.
 -   **key**: `JWKInterface`: The Key to use for signing transactions. Should be a JWK object.
--   **turbo (optional)**: An authenticated Turbo instance to use for uploading with Turbo.
 
 <Warning>
     Private keys must be kept secure at all times. Please ensure that the
@@ -166,3 +165,23 @@ const toolkit = new AtomicToolkit({
     warp,
 });
 ```
+
+## Using Turbo SDK
+
+```ts
+import { TurboFactory } from '@ardrive/turbo-sdk';
+import AtomicToolkit from 'atomic-toolkit';
+import fs from 'fs';
+
+const jwk = JSON.parse(fs.readFileSync('./KeyFile.json'));
+
+const turbo = TurboFactory.authenticated({ privateKey: jwk });
+const toolkit = new AtomicToolkit({ turbo });
+```
+
+### Input Parameters
+
+The following params are available for this function and they must be passed in as an object:
+
+-   **warp (optional)**: `Warp`: A Warp Instance to use with Deploy Plugin. If not provided, the default Warp instance for Mainnet will be used.
+-   **turbo**: An authenticated Turbo instance to use for uploading with Turbo.

--- a/packages/atomic-toolkit/package.json
+++ b/packages/atomic-toolkit/package.json
@@ -54,6 +54,7 @@
         "access": "public"
     },
     "dependencies": {
+        "@ardrive/turbo-sdk": "^1.3.0",
         "@irys/sdk": "^0.1.1",
         "arbundles": "^0.10.0",
         "arweave": "^1.14.4",

--- a/packages/atomic-toolkit/src/base.ts
+++ b/packages/atomic-toolkit/src/base.ts
@@ -8,14 +8,14 @@ import { getConfig } from './lib/config';
 // Types
 import * as Types from './types';
 import { JWKInterface } from 'arweave/node/lib/wallet';
-import { TurboAuthenticatedClientInterface, TurboUnauthenticatedClientInterface, } from '@ardrive/turbo-sdk';
+import { TurboAuthenticatedClientInterface } from '@ardrive/turbo-sdk';
 
 class AtomicToolkitBase {
     protected warp: Warp;
     protected arweaveInstance: Arweave;
     protected irys: WebIrys | Irys | null | undefined;
     protected key: JWKInterface | 'use_wallet' | null;
-    protected turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
+    protected turbo: TurboAuthenticatedClientInterface | null | undefined;
 
     constructor(
         opts: Types.AtomicToolkitNodeOpts | Types.AtomicToolkitWebOpts,
@@ -26,7 +26,7 @@ class AtomicToolkitBase {
         this.arweaveInstance = arweave;
         this.irys = irys;
         this.key = key;
-        this.turbo = turbo
+        this.turbo = turbo;
     }
 }
 

--- a/packages/atomic-toolkit/src/base.ts
+++ b/packages/atomic-toolkit/src/base.ts
@@ -8,22 +8,25 @@ import { getConfig } from './lib/config';
 // Types
 import * as Types from './types';
 import { JWKInterface } from 'arweave/node/lib/wallet';
+import { TurboAuthenticatedClientInterface, TurboUnauthenticatedClientInterface, } from '@ardrive/turbo-sdk';
 
 class AtomicToolkitBase {
     protected warp: Warp;
     protected arweaveInstance: Arweave;
     protected irys: WebIrys | Irys | null | undefined;
     protected key: JWKInterface | 'use_wallet' | null;
+    protected turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
 
     constructor(
         opts: Types.AtomicToolkitNodeOpts | Types.AtomicToolkitWebOpts,
     ) {
-        const { warp, arweave, irys, key } = getConfig(opts);
+        const { warp, arweave, irys, key, turbo } = getConfig(opts);
 
         this.warp = warp;
         this.arweaveInstance = arweave;
         this.irys = irys;
         this.key = key;
+        this.turbo = turbo
     }
 }
 

--- a/packages/atomic-toolkit/src/lib/collection/index.ts
+++ b/packages/atomic-toolkit/src/lib/collection/index.ts
@@ -23,6 +23,7 @@ import type { Tag } from 'arbundles';
 import * as Types from '../../types';
 import Transaction from 'arweave/node/lib/transaction';
 import { UploadResponse } from '@irys/sdk/build/cjs/common/types';
+import { TurboUploadDataItemResponse } from '@ardrive/turbo-sdk';
 
 class Collection extends ModuleBase {
     protected assets: AtomicAssets;
@@ -38,7 +39,7 @@ class Collection extends ModuleBase {
 
     public async createCollectionWithAssetIds(
         opts: Types.CreateCollectionWithAssetIdsOpts,
-    ): Promise<UploadResponse | Transaction> {
+    ): Promise<UploadResponse | Transaction | TurboUploadDataItemResponse> {
         const data = {
             type: 'Collection',
             items: opts.assetIds,

--- a/packages/atomic-toolkit/src/lib/config.ts
+++ b/packages/atomic-toolkit/src/lib/config.ts
@@ -3,6 +3,7 @@ import { Warp, WarpFactory } from 'warp-contracts';
 import { DeployPlugin } from 'warp-contracts-plugin-deploy';
 import Irys, { WebIrys } from '@irys/sdk';
 import { JWKInterface } from 'arbundles';
+import { TurboAuthenticatedClientInterface, TurboFactory, TurboUnauthenticatedClientInterface } from '@ardrive/turbo-sdk';
 
 import * as Types from '../types';
 
@@ -17,6 +18,8 @@ export const defaultArweave = new ArweaveClass({
     protocol: 'https',
 });
 
+export const defaultTurbo = TurboFactory.unauthenticated()
+
 export const getConfig = (
     opts: Types.AtomicToolkitNodeOpts | Types.AtomicToolkitWebOpts,
 ) => {
@@ -24,6 +27,7 @@ export const getConfig = (
     let baseArweave: Arweave;
     let baseIrys: WebIrys | Irys | null | undefined;
     let baseKey: JWKInterface | 'use_wallet' | null;
+    let baseTurbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
     const { warp, ...props } = opts;
 
     if (warp) {
@@ -42,6 +46,13 @@ export const getConfig = (
         baseIrys = irys;
         baseArweave = defaultArweave;
         baseKey = null;
+        baseTurbo = defaultTurbo;
+    } else if (typeof props === 'object' && 'turbo' in props) {
+        const { turbo } = props as Types.AtomicToolkitWithTurbo;
+        baseTurbo = turbo ?? defaultTurbo;
+        baseArweave = defaultArweave;
+        baseKey = null;
+        baseIrys = null;
     } else {
         const { arweave, key } = props as
             | Types.AtomicToolkitWithArweave
@@ -49,6 +60,7 @@ export const getConfig = (
         baseArweave = arweave ?? defaultArweave;
         baseKey = key ?? 'use_wallet';
         baseIrys = null;
+        baseTurbo = defaultTurbo;
     }
 
     return {
@@ -56,5 +68,6 @@ export const getConfig = (
         arweave: baseArweave,
         irys: baseIrys,
         key: baseKey,
+        turbo: baseTurbo,
     };
 };

--- a/packages/atomic-toolkit/src/lib/config.ts
+++ b/packages/atomic-toolkit/src/lib/config.ts
@@ -3,7 +3,7 @@ import { Warp, WarpFactory } from 'warp-contracts';
 import { DeployPlugin } from 'warp-contracts-plugin-deploy';
 import Irys, { WebIrys } from '@irys/sdk';
 import { JWKInterface } from 'arbundles';
-import { TurboAuthenticatedClientInterface, TurboFactory, TurboUnauthenticatedClientInterface } from '@ardrive/turbo-sdk';
+import { TurboAuthenticatedClientInterface, TurboFactory} from '@ardrive/turbo-sdk';
 
 import * as Types from '../types';
 
@@ -18,8 +18,6 @@ export const defaultArweave = new ArweaveClass({
     protocol: 'https',
 });
 
-export const defaultTurbo = TurboFactory.unauthenticated()
-
 export const getConfig = (
     opts: Types.AtomicToolkitNodeOpts | Types.AtomicToolkitWebOpts,
 ) => {
@@ -27,7 +25,7 @@ export const getConfig = (
     let baseArweave: Arweave;
     let baseIrys: WebIrys | Irys | null | undefined;
     let baseKey: JWKInterface | 'use_wallet' | null;
-    let baseTurbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
+    let baseTurbo: TurboAuthenticatedClientInterface | null;
     const { warp, ...props } = opts;
 
     if (warp) {
@@ -46,10 +44,10 @@ export const getConfig = (
         baseIrys = irys;
         baseArweave = defaultArweave;
         baseKey = null;
-        baseTurbo = defaultTurbo;
+        baseTurbo = null;
     } else if (typeof props === 'object' && 'turbo' in props) {
         const { turbo } = props as Types.AtomicToolkitWithTurbo;
-        baseTurbo = turbo ?? defaultTurbo;
+        baseTurbo = turbo ?? null;
         baseArweave = defaultArweave;
         baseKey = null;
         baseIrys = null;
@@ -60,7 +58,7 @@ export const getConfig = (
         baseArweave = arweave ?? defaultArweave;
         baseKey = key ?? 'use_wallet';
         baseIrys = null;
-        baseTurbo = defaultTurbo;
+        baseTurbo = null;
     }
 
     return {

--- a/packages/atomic-toolkit/src/lib/index.ts
+++ b/packages/atomic-toolkit/src/lib/index.ts
@@ -2,6 +2,7 @@ import Arweave from 'arweave';
 import { Warp } from 'warp-contracts';
 import { JWKInterface } from 'arbundles';
 import Irys, { WebIrys } from '@irys/sdk';
+import { TurboAuthenticatedClientInterface, TurboUnauthenticatedClientInterface } from '@ardrive/turbo-sdk';
 
 import * as Types from '../types';
 
@@ -10,12 +11,14 @@ class ModuleBase {
     protected arweave: Arweave;
     protected irys: WebIrys | Irys | null;
     protected key: JWKInterface | 'use_wallet' | null;
+    protected turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface
 
     constructor(opts: Types.ModuleOpts) {
         this.warp = opts.warp;
         this.arweave = opts.arweave;
         this.irys = opts.irys;
         this.key = opts.key;
+        this.turbo = opts.turbo
     }
 }
 

--- a/packages/atomic-toolkit/src/lib/index.ts
+++ b/packages/atomic-toolkit/src/lib/index.ts
@@ -11,7 +11,7 @@ class ModuleBase {
     protected arweave: Arweave;
     protected irys: WebIrys | Irys | null;
     protected key: JWKInterface | 'use_wallet' | null;
-    protected turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface
+    protected turbo: TurboAuthenticatedClientInterface | null
 
     constructor(opts: Types.ModuleOpts) {
         this.warp = opts.warp;

--- a/packages/atomic-toolkit/src/lib/upload/index.ts
+++ b/packages/atomic-toolkit/src/lib/upload/index.ts
@@ -1,8 +1,9 @@
 import { WebIrys } from '@irys/sdk';
 import { TurboFileFactory, DataItemOptions } from '@ardrive/turbo-sdk';
+
 import * as Types from '../../types/upload';
 import Mime from 'mime';
-import { Readable } from 'stream'
+import { Readable } from 'stream';
 
 const uploadWithIrys = async (opts: Types.IrysUploadParams) => {
     const { irys } = opts;
@@ -47,6 +48,7 @@ const uploadWithIrys = async (opts: Types.IrysUploadParams) => {
 const uploadWithArweave = async (opts: Types.ArweaveUploadParams) => {
     try {
         const { arweave, jwk, type, data, tags } = opts;
+
         let dataToUpload: string | ArrayBuffer;
         if (type === 'data' && typeof data === 'string') {
             dataToUpload = data;
@@ -96,42 +98,46 @@ const uploadWithArweave = async (opts: Types.ArweaveUploadParams) => {
 const uploadWithTurbo = async (opts: Types.TurboUploadParams) => {
     const { turbo, type, data, tags } = opts;
 
-    let fileStreamFactory;
-    let fileSizeFactory;
-    let dataItemOpts: DataItemOptions = {
-        tags: tags.map((tag) => ({ name: tag.name, value: tag.value })),
-    };
+    {
+        console.log('This is the upload with turbo function');
 
-    if (data instanceof File) {
-        // Browser environment, data is a File object
-        fileStreamFactory = () => data.stream() as unknown as Readable;
-        fileSizeFactory = () => data.size;
-    } else if (type === 'data' && typeof data === 'string') {
-        // Handling raw data as a string
-        const buffer = Buffer.from(data);
-        fileStreamFactory = () => Readable.from(buffer);
-        fileSizeFactory = () => buffer.length;
-    } else if (type === 'file' && typeof data === 'string') {
-        // Node.js environment, data is assumed to be a file path
-        const fs = require('fs');
-        fileStreamFactory = () => fs.createReadStream(data);
-        fileSizeFactory = () => fs.statSync(data).size;
-    } else {
-        throw new Error('Invalid type or data format');
-    }
+        let fileStreamFactory;
+        let fileSizeFactory;
+        let dataItemOpts: DataItemOptions = {
+            tags: tags.map((tag) => ({ name: tag.name, value: tag.value })),
+        };
 
-    const uploadParams: TurboFileFactory = {
-        fileStreamFactory,
-        fileSizeFactory,
-        dataItemOpts,
-    };
+        if (data instanceof File) {
+            // Browser environment, data is a File object
+            fileStreamFactory = () => data.stream() as unknown as Readable;
+            fileSizeFactory = () => data.size;
+        } else if (type === 'data' && typeof data === 'string') {
+            // Handling raw data as a string
+            const buffer = Buffer.from(data);
+            fileStreamFactory = () => Readable.from(buffer);
+            fileSizeFactory = () => buffer.length;
+        } else if (type === 'file' && typeof data === 'string') {
+            // Node.js environment, data is assumed to be a file path
+            const fs = require('fs');
+            fileStreamFactory = () => fs.createReadStream(data);
+            fileSizeFactory = () => fs.statSync(data).size;
+        } else {
+            throw new Error('Invalid type or data format');
+        }
 
-    try {
-        // Perform file upload using Turbo SDK
-        const tx = await turbo.uploadFile(uploadParams);
-        return tx;
-    } catch (error) {
-        throw new Error(String(error));
+        const uploadParams: TurboFileFactory = {
+            fileStreamFactory,
+            fileSizeFactory,
+            dataItemOpts,
+        };
+
+        try {
+            // Perform file upload using Turbo SDK
+            const tx = await turbo.uploadFile(uploadParams);
+            return tx;
+        } catch (error) {
+            throw new Error(String(error));
+        }
     }
 };
 

--- a/packages/atomic-toolkit/src/lib/upload/index.ts
+++ b/packages/atomic-toolkit/src/lib/upload/index.ts
@@ -1,6 +1,8 @@
 import { WebIrys } from '@irys/sdk';
+import { TurboFileFactory, DataItemOptions } from '@ardrive/turbo-sdk';
 import * as Types from '../../types/upload';
 import Mime from 'mime';
+import { Readable } from 'stream'
 
 const uploadWithIrys = async (opts: Types.IrysUploadParams) => {
     const { irys } = opts;
@@ -91,4 +93,46 @@ const uploadWithArweave = async (opts: Types.ArweaveUploadParams) => {
     }
 };
 
-export { uploadWithArweave, uploadWithIrys };
+const uploadWithTurbo = async (opts: Types.TurboUploadParams) => {
+    const { turbo, type, data, tags } = opts;
+
+    let fileStreamFactory;
+    let fileSizeFactory;
+    let dataItemOpts: DataItemOptions = {
+        tags: tags.map((tag) => ({ name: tag.name, value: tag.value })),
+    };
+
+    if (data instanceof File) {
+        // Browser environment, data is a File object
+        fileStreamFactory = () => data.stream() as unknown as Readable;
+        fileSizeFactory = () => data.size;
+    } else if (type === 'data' && typeof data === 'string') {
+        // Handling raw data as a string
+        const buffer = Buffer.from(data);
+        fileStreamFactory = () => Readable.from(buffer);
+        fileSizeFactory = () => buffer.length;
+    } else if (type === 'file' && typeof data === 'string') {
+        // Node.js environment, data is assumed to be a file path
+        const fs = require('fs');
+        fileStreamFactory = () => fs.createReadStream(data);
+        fileSizeFactory = () => fs.statSync(data).size;
+    } else {
+        throw new Error('Invalid type or data format');
+    }
+
+    const uploadParams: TurboFileFactory = {
+        fileStreamFactory,
+        fileSizeFactory,
+        dataItemOpts,
+    };
+
+    try {
+        // Perform file upload using Turbo SDK
+        const tx = await turbo.uploadFile(uploadParams);
+        return tx;
+    } catch (error) {
+        throw new Error(String(error));
+    }
+};
+
+export { uploadWithArweave, uploadWithIrys, uploadWithTurbo };

--- a/packages/atomic-toolkit/src/lib/upload/index.ts
+++ b/packages/atomic-toolkit/src/lib/upload/index.ts
@@ -99,8 +99,6 @@ const uploadWithTurbo = async (opts: Types.TurboUploadParams) => {
     const { turbo, type, data, tags } = opts;
 
     {
-        console.log('This is the upload with turbo function');
-
         let fileStreamFactory;
         let fileSizeFactory;
         let dataItemOpts: DataItemOptions = {

--- a/packages/atomic-toolkit/src/lib/utils/index.ts
+++ b/packages/atomic-toolkit/src/lib/utils/index.ts
@@ -134,10 +134,6 @@ class Utilities extends ModuleBase {
     public async uploadData(
         opts: Types.UploadDataOpts,
     ): Promise<Transaction | UploadResponse | TurboUploadDataItemResponse> {
-        if (this.turbo) {
-            console.log('Turbo exists');
-            console.log(this.turbo);
-        }
         if (this.irys) {
             const tx = uploadWithIrys({
                 irys: this.irys,
@@ -147,7 +143,6 @@ class Utilities extends ModuleBase {
             });
             return tx;
         } else if (this.turbo) {
-            console.log('using turbo');
             const tx = uploadWithTurbo({
                 turbo: this.turbo,
                 type: opts.type,
@@ -159,7 +154,6 @@ class Utilities extends ModuleBase {
             if (!this.arweave || !this.key) {
                 throw new Error('Arweave and JWK must be defined');
             }
-            console.log('using arweave');
             const tx = uploadWithArweave({
                 arweave: this.arweave,
                 jwk: this.key,

--- a/packages/atomic-toolkit/src/lib/utils/index.ts
+++ b/packages/atomic-toolkit/src/lib/utils/index.ts
@@ -143,8 +143,6 @@ class Utilities extends ModuleBase {
             });
             return tx;
         } else if (this.turbo instanceof TurboAuthenticatedClient){
-            console.log("Uploading with Turbo... Boop Beep Boop")
-
             const tx = uploadWithTurbo({
                 turbo: this.turbo,
                 type: opts.type,

--- a/packages/atomic-toolkit/src/lib/utils/index.ts
+++ b/packages/atomic-toolkit/src/lib/utils/index.ts
@@ -82,7 +82,7 @@ class Utilities extends ModuleBase {
             const c = Number(c1[0]["winc"]);
             const a = c - b;
 
-           token = 'arweave'
+           token = 'turbo'
            balance={
             atomic: b1['winc'],
             formatted: (b / 1000000000000).toString()

--- a/packages/atomic-toolkit/src/types/index.ts
+++ b/packages/atomic-toolkit/src/types/index.ts
@@ -2,6 +2,7 @@ import Arweave from 'arweave';
 import { Warp } from 'warp-contracts';
 import Irys, { WebIrys } from '@irys/sdk';
 import { JWKInterface } from 'arweave/node/lib/wallet';
+import { TurboAuthenticatedClientInterface, TurboUnauthenticatedClientInterface } from '@ardrive/turbo-sdk';
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> = T | U extends object
@@ -34,9 +35,14 @@ export type AtomicToolkitWithIrys = {
     irys: Irys;
 };
 
+export type AtomicToolkitWithTurbo = {
+    warp?: Warp;
+    turbo?: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
+};
+
 export type AtomicToolkitNodeOpts = XOR<
-    AtomicToolkitWithArweave,
-    AtomicToolkitWithIrys
+    AtomicToolkitWithTurbo,
+    XOR<AtomicToolkitWithIrys, AtomicToolkitWithArweave>
 >;
 
 export type AtomicToolkitWebWithArweave = {
@@ -69,7 +75,7 @@ export type AtomicToolkitWebWithIrys = {
 
 export type AtomicToolkitWebOpts = XOR<
     AtomicToolkitWebWithArweave,
-    AtomicToolkitWebWithIrys
+    XOR<AtomicToolkitWebWithIrys, AtomicToolkitWithTurbo>
 >;
 
 export type ModuleOpts = {
@@ -91,6 +97,10 @@ export type ModuleOpts = {
      * Irys Configuration Options
      */
     irys: WebIrys | Irys | null;
+    /**
+     * Turbo Configuration Options
+     */
+    turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
 };
 
 export * from './asset';

--- a/packages/atomic-toolkit/src/types/index.ts
+++ b/packages/atomic-toolkit/src/types/index.ts
@@ -2,7 +2,9 @@ import Arweave from 'arweave';
 import { Warp } from 'warp-contracts';
 import Irys, { WebIrys } from '@irys/sdk';
 import { JWKInterface } from 'arweave/node/lib/wallet';
-import { TurboAuthenticatedClientInterface, TurboUnauthenticatedClientInterface } from '@ardrive/turbo-sdk';
+import { TurboAuthenticatedClientInterface} from '@ardrive/turbo-sdk';
+
+
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> = T | U extends object
@@ -37,7 +39,7 @@ export type AtomicToolkitWithIrys = {
 
 export type AtomicToolkitWithTurbo = {
     warp?: Warp;
-    turbo?: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
+    turbo?: TurboAuthenticatedClientInterface | null
 };
 
 export type AtomicToolkitNodeOpts = XOR<
@@ -73,9 +75,14 @@ export type AtomicToolkitWebWithIrys = {
     irys: WebIrys;
 };
 
+export type AtomicToolkitWebWithTurbo = {
+    warp?: Warp;
+    turbo?: TurboAuthenticatedClientInterface | null
+}
+
 export type AtomicToolkitWebOpts = XOR<
     AtomicToolkitWebWithArweave,
-    XOR<AtomicToolkitWebWithIrys, AtomicToolkitWithTurbo>
+    XOR<AtomicToolkitWebWithIrys, AtomicToolkitWebWithTurbo>
 >;
 
 export type ModuleOpts = {
@@ -100,7 +107,7 @@ export type ModuleOpts = {
     /**
      * Turbo Configuration Options
      */
-    turbo: TurboAuthenticatedClientInterface | TurboUnauthenticatedClientInterface;
+    turbo: TurboAuthenticatedClientInterface | null;
 };
 
 export * from './asset';

--- a/packages/atomic-toolkit/src/types/upload.ts
+++ b/packages/atomic-toolkit/src/types/upload.ts
@@ -2,6 +2,7 @@ import Arweave from 'arweave';
 import { Tag } from 'arbundles';
 import Irys, { WebIrys } from '@irys/sdk';
 import { JWKInterface } from 'arweave/node/lib/wallet';
+import { TurboAuthenticatedClientInterface } from '@ardrive/turbo-sdk';
 
 export type ArweaveUploadParams = {
     arweave: Arweave;
@@ -34,6 +35,13 @@ export type WebIrysUploadParams = {
 
 export type IrysUploadParams = {
     irys: WebIrys | Irys;
+    type: 'data' | 'file';
+    data: string | File;
+    tags: Tag[];
+};
+
+export type TurboUploadParams = {
+    turbo: TurboAuthenticatedClientInterface;
     type: 'data' | 'file';
     data: string | File;
     tags: Tag[];

--- a/packages/atomic-toolkit/tests/utils/index.test.ts
+++ b/packages/atomic-toolkit/tests/utils/index.test.ts
@@ -7,6 +7,7 @@ import * as dotenv from 'dotenv';
 dotenv.config({ path: '.env.local' });
 
 import { readFileSync } from 'fs';
+import { TurboFactory } from '@ardrive/turbo-sdk';
 const key = JSON.parse(readFileSync('./wallet.json').toString());
 
 describe('Utilities', () => {
@@ -44,6 +45,14 @@ describe('Utilities', () => {
         const toolkit = new AtomicToolkit({
             irys,
         });
+
+        const cost = await toolkit.utils.getUploadCost(10 ** 9);
+        expect(cost).toBeDefined();
+    });
+    it('should return cost to upload data using Turbo', async () => {
+        const turbo = TurboFactory.authenticated({privateKey: key})
+
+        const toolkit = new AtomicToolkit({turbo})
 
         const cost = await toolkit.utils.getUploadCost(10 ** 9);
         expect(cost).toBeDefined();

--- a/packages/atomic-toolkit/tests/utils/index.test.ts
+++ b/packages/atomic-toolkit/tests/utils/index.test.ts
@@ -33,6 +33,21 @@ describe('Utilities', () => {
         const cost = await toolkit.utils.getUploadCost(10 ** 9);
         expect(cost).toBeDefined();
     });
+    it('should return cost to upload data using irys through Turbo', async () => {
+        const irys = new Irys({
+            url: 'https://up.arweave.net',
+            token: 'matic',
+            key: process.env.PRIVATE_KEY,
+        });
+
+        await irys.ready();
+        const toolkit = new AtomicToolkit({
+            irys,
+        });
+
+        const cost = await toolkit.utils.getUploadCost(10 ** 9);
+        expect(cost).toBeDefined();
+    });
     it('should return directory size', async () => {
         const toolkit = new AtomicToolkit({
             key,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
 
   packages/atomic-toolkit:
     dependencies:
+      '@ardrive/turbo-sdk':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@irys/sdk':
         specifier: ^0.1.1
         version: 0.1.1(arweave@1.14.4)
@@ -503,6 +506,22 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: true
+
+  /@ardrive/turbo-sdk@1.3.0:
+    resolution: {integrity: sha512-3/Tpt1M/HdOr4srbbeAizEVjaKvqdVYqA/pbIBlY9uj3uw5/HdKKCUOea7M5rypPw+QXlT/d66/AlLV335I8lQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      arbundles: 0.9.11
+      arweave: 1.14.4
+      axios: 1.6.2(debug@4.3.4)
+      axios-retry: 3.9.1
+      winston: 3.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - utf-8-validate
+    dev: false
 
   /@auth0/auth0-spa-js@2.1.3:
     resolution: {integrity: sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ==}
@@ -2233,9 +2252,22 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@colors/colors@1.6.0:
+    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
+    engines: {node: '>=0.1.90'}
+    dev: false
+
   /@ctrl/tinycolor@3.6.1:
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /@dabh/diagnostics@2.0.3:
+    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
+    dependencies:
+      colorspace: 1.1.4
+      enabled: 2.0.0
+      kuler: 2.0.0
     dev: false
 
   /@emotion/babel-plugin@11.11.0:
@@ -6774,6 +6806,10 @@ packages:
       '@types/node': 18.19.3
     dev: false
 
+  /@types/triple-beam@1.3.5:
+    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+    dev: false
+
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: false
@@ -8495,6 +8531,13 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /axios-retry@3.9.1:
+    resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
+    dependencies:
+      '@babel/runtime': 7.23.6
+      is-retry-allowed: 2.2.0
+    dev: false
+
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
@@ -9367,13 +9410,34 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: false
+
   /color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
     dev: false
 
+  /color@3.2.1:
+    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+    dependencies:
+      color-convert: 1.9.3
+      color-string: 1.9.1
+    dev: false
+
   /colorette@2.0.16:
     resolution: {integrity: sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==}
+
+  /colorspace@1.1.4:
+    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
+    dependencies:
+      color: 3.2.1
+      text-hex: 1.0.0
+    dev: false
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -10073,6 +10137,10 @@ packages:
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /enabled@2.0.0:
+    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
+    dev: false
 
   /encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
@@ -10899,6 +10967,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
+    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
@@ -11178,6 +11247,10 @@ packages:
       - encoding
     dev: true
 
+  /fecha@4.2.3:
+    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+    dev: false
+
   /fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
     dev: false
@@ -11261,6 +11334,10 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
+
+  /fn.name@1.1.0:
+    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
+    dev: false
 
   /follow-redirects@1.15.3(debug@4.3.4):
     resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
@@ -12195,6 +12272,10 @@ packages:
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  /is-arrayish@0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
+
   /is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
     engines: {node: '>= 0.4'}
@@ -12372,6 +12453,11 @@ packages:
     dependencies:
       is-unc-path: 1.0.0
     dev: true
+
+  /is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
+    dev: false
 
   /is-set@2.0.2:
     resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
@@ -12979,6 +13065,10 @@ packages:
       - supports-color
     dev: false
 
+  /kuler@2.0.0:
+    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
+    dev: false
+
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: true
@@ -13269,6 +13359,18 @@ packages:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
     dev: true
+
+  /logform@2.6.0:
+    resolution: {integrity: sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@types/triple-beam': 1.3.5
+      fecha: 4.2.3
+      ms: 2.1.3
+      safe-stable-stringify: 2.4.1
+      triple-beam: 1.4.1
+    dev: false
 
   /loglevel@1.8.1:
     resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
@@ -13762,7 +13864,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /multibase@4.0.6:
     resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
@@ -14264,6 +14365,12 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+
+  /one-time@1.0.0:
+    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
+    dependencies:
+      fn.name: 1.1.0
+    dev: false
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -16411,6 +16518,12 @@ packages:
       simple-concat: 1.0.1
     dev: false
 
+  /simple-swizzle@0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+    dependencies:
+      is-arrayish: 0.3.2
+    dev: false
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -16629,6 +16742,10 @@ packages:
       minipass: 3.3.6
     dev: false
     optional: true
+
+  /stack-trace@0.0.10:
+    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+    dev: false
 
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -16986,6 +17103,10 @@ packages:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
     dev: false
 
+  /text-hex@1.0.0:
+    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+    dev: false
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -17147,6 +17268,11 @@ packages:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
     dev: true
+
+  /triple-beam@1.4.1:
+    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
+    engines: {node: '>= 14.0.0'}
+    dev: false
 
   /ts-api-utils@1.0.3(typescript@5.3.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
@@ -18481,6 +18607,32 @@ packages:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
       string-width: 4.2.3
+    dev: false
+
+  /winston-transport@4.6.0:
+    resolution: {integrity: sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      logform: 2.6.0
+      readable-stream: 3.6.2
+      triple-beam: 1.4.1
+    dev: false
+
+  /winston@3.11.0:
+    resolution: {integrity: sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@dabh/diagnostics': 2.0.3
+      async: 3.2.5
+      is-stream: 2.0.1
+      logform: 2.6.0
+      one-time: 1.0.0
+      readable-stream: 3.6.2
+      safe-stable-stringify: 2.4.1
+      stack-trace: 0.0.10
+      triple-beam: 1.4.1
+      winston-transport: 4.6.0
     dev: false
 
   /wonka@6.3.4:


### PR DESCRIPTION
This PR introduces the integration of Turbo, an open-source upload and payment service by ArDrive, into the Atomic-Toolkit. Turbo facilitates the process of uploading data to Arweave, offering a user-friendly payment alternative through the use of Turbo Credits. These credits can be purchased using a credit card and offer a 1:1 upload value in comparison to AR tokens, making the upload process more accessible.

Key Enhancements:

1. Turbo Integration: Users can now choose to use Turbo for uploading data to Arweave, providing flexibility in payment options.
2. Increased Accessibility: With the option to purchase Turbo Credits via credit card, this update makes the Atomic-Toolkit more accessible to a broader user base.
3. Enhanced Utility: The integration broadens the scope and utility of the Atomic-Toolkit, catering to varied user preferences and needs.
4. This update aligns with the goal of enhancing the Atomic-Toolkit's functionality and user experience, offering an additional, convenient method for users to manage their data uploads to Arweave.

Get more information about Turbo from the [official documentation](https://docs.ardrive.io/docs/turbo/what-is-turbo.html)