### PR TITLE
fix(Turbo-Irys): Fixed Irys node issue in Warp when using Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Using Turbo Through Irys:
 import Irys from '@irys/sdk';
 
 const irys = new Irys({
-    url: 'https://up.arweave.net',
+    url: 'https://turbo.ardrive.io',
     token: 'matic',
     key: 'your-private-key',
 });

--- a/packages/atomic-toolkit/src/lib/utils/index.ts
+++ b/packages/atomic-toolkit/src/lib/utils/index.ts
@@ -173,6 +173,7 @@ class Utilities extends ModuleBase {
         }
         const url = this.irys.api.config.url.href;
 
+        // Checks for Turbo urls being used in Irys
         if (
             url.includes('up.arweave.net') ||
             url.includes('turbo.ardrive.io')

--- a/packages/atomic-toolkit/src/lib/utils/index.ts
+++ b/packages/atomic-toolkit/src/lib/utils/index.ts
@@ -172,11 +172,25 @@ class Utilities extends ModuleBase {
             throw new Error('Irys is not defined');
         }
         const url = this.irys.api.config.url.href;
+
+        if (
+            url.includes('up.arweave.net') ||
+            url.includes('turbo.ardrive.io')
+        ) {
+            return 'arweave';
+        }
+
         const node = url?.split('https://')[1]?.split('.irys.xyz')[0];
         if (node === 'devnet') {
             throw new Error('Only Node1 and Node2 are supported');
         }
-        return node as 'node1' | 'node2';
+
+        if (node === 'node1' || node === 'node2') {
+            return node;
+        }
+
+        // Catch-all error for unexpected URLs
+        throw new Error('Unrecognized or unsupported URL');
     }
 }
 

--- a/packages/atomic-toolkit/tests/utils/index.test.ts
+++ b/packages/atomic-toolkit/tests/utils/index.test.ts
@@ -36,7 +36,7 @@ describe('Utilities', () => {
     });
     it('should return cost to upload data using irys through Turbo', async () => {
         const irys = new Irys({
-            url: 'https://up.arweave.net',
+            url: 'https://turbo.ardrive.io',
             token: 'matic',
             key: process.env.PRIVATE_KEY,
         });


### PR DESCRIPTION
- Updated getIrysNode function to return 'arweave' if Turbo urls (`https://up.arweave.net` or `https://turbo.ardrive.io`) are used to instantiate Irys.

- Added catch-all error in getIrysNode function to catch possible unsupported node options.

- Updated docs for using Turbo with Irys to use `https://turbo.ardrive.io` instead of `https://up.arweave.net` since the former offers better performance.

These updates should resolve errors in registering warp contracts when using Turbo through Irys.